### PR TITLE
Click handler got return value

### DIFF
--- a/js/jquery.inline-confirmation.js
+++ b/js/jquery.inline-confirmation.js
@@ -57,6 +57,7 @@
     };
 
     var original_action;
+    var timeout_id;
     var all_actions     = $(this);
     var options         = $.extend(defaults, options);
     var block_class     = "inline-confirmation-block";
@@ -90,7 +91,7 @@
       }
 
       if (options.expiresIn > 0) {
-        setTimeout(function() {
+        timeout_id = setTimeout(function() {
           $("span." + block_class, original_action.parent()).hide();
           original_action.show();
         }, options.expiresIn * 1000);
@@ -100,6 +101,7 @@
     });
 
     $(this).parent().delegate("span." + action_class, "click", function() {
+      clearTimeout(timeout_id);
       $(this).parent().hide();
       original_action.show();
 

--- a/js/jquery.inline-confirmation.js
+++ b/js/jquery.inline-confirmation.js
@@ -111,6 +111,7 @@
       } else {
         options.cancelCallback.apply(this, args);
       }
+      return false;
     });
   };
 


### PR DESCRIPTION
Here is a fix that prevents page to navigate to '#' on action confirmation
